### PR TITLE
INT-46-Incorrect-option-selected-when-clicked-during-practice-trials-for-second-phase

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,6 +111,7 @@ declare type TrialState = {
   hasSelected: boolean;
   highlightedOptionIndex: number;
   selectedOption: Options;
+  answer: Options;
 };
 
 // Points storage


### PR DESCRIPTION
* Issue was arising due to overcomplicating state management and removing use of `useState`.