### PR TITLE
INT-60-Add-pop-ups-to-highlight-UI-elements

### DIFF
--- a/src/classes/factories/ScreenPropFactory.ts
+++ b/src/classes/factories/ScreenPropFactory.ts
@@ -82,6 +82,7 @@ class ScreenPropFactory implements Factory {
           trial: this.trial.trial,
           display: this.trial.display,
           isPractice: this.trial.isPractice,
+          spotlight: this.trial.spotlight,
           participantPoints: participantPoints,
           partnerPoints: partnerPoints,
           options: {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -379,6 +379,28 @@ if (Flags.isEnabled("enableStatusDisplay") === true) {
     fetchData: false,
   });
 }
+
+// Introduce the status display if enabled
+if (Flags.isEnabled("enableStatusDisplay") === true) {
+  timeline.push({
+    type: Configuration.studyName,
+    optionOneParticipant: 5,
+    optionOnePartner: 9,
+    optionTwoParticipant: 9,
+    optionTwoPartner: 9,
+    typeOne: "",
+    typeTwo: "",
+    display: "playerChoicePractice",
+    answer: "Option 1",
+    isPractice: true,
+    spotlight: {
+      enabled: true,
+      target: "status",
+      message: "In some trials, you will be able to see your social standing in relation to your partner, based on the information you provided.",
+    },
+  });
+}
+
 // Post-'playerChoice' instructions
 timeline.push({
   type: "instructions",
@@ -543,13 +565,13 @@ timeline.push({
   show_clickable_nav: true,
 });
 
-      // Insert the matching sequence into the timeline
-      timeline.push({
-        type: Configuration.studyName,
-        display: "loading",
-        loadingType: "matching",
-        fetchData: false,
-      });
+// Insert the matching sequence into the timeline
+timeline.push({
+  type: Configuration.studyName,
+  display: "loading",
+  loadingType: "matching",
+  fetchData: false,
+});
 
 timeline.push({
   type: Configuration.studyName,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -97,6 +97,16 @@ jsPsych.plugins[Configuration.studyName] = (() => {
         default: false,
         description: "Show feedback to participants",
       },
+      spotlight: {
+        type: jsPsych.plugins.parameterType.OBJECT,
+        pretty_name: "Spotlight",
+        default: {
+          enabled: false,
+          target: "",
+          message: "",
+        },
+        description: "Spotlight a UI component with a closeable message",
+      },
       fetchData: {
         type: jsPsych.plugins.parameterType.BOOLEAN,
         pretty_name: "Enable or disable server queries",

--- a/src/view/components/Status/index.tsx
+++ b/src/view/components/Status/index.tsx
@@ -38,10 +38,9 @@ const Status: FC<Props.Components.Status> = (
     Configuration.avatars.names.participant[
       experiment.getState().get("participantAvatar")
     ];
-  const partnerAvatarName =
-    Configuration.avatars.names.partner[
-      experiment.getState().get("partnerAvatar")
-    ];
+  const partnerAvatarName = props.isPractice === true ? "example" : Configuration.avatars.names.partner[
+    experiment.getState().get("partnerAvatar")
+  ];
 
   // Calculate positions as percentages (0-100)
   const participantPosition = `${participantStatus}%`;

--- a/src/view/screens/Trial/index.tsx
+++ b/src/view/screens/Trial/index.tsx
@@ -582,7 +582,53 @@ const Trial: FC<Props.Screens.Trial> = (
   return (
     <Keyboard onKeyDown={inputHandler} target={"document"}>
       <Box align="center" justify="center" fill>
-        {/* Status component - only show if enabled for this phase and not a practice trial */}
+
+        {/* Status component - display in practice cases only if the spotlight functionality is enabled */}
+        {Flags.isEnabled("enableStatusDisplay") &&
+          props.isPractice === true &&
+          props.spotlight?.enabled === true &&
+          props.spotlight.target === "status" && (
+            <>
+              <Box
+                style={{
+                  position: "fixed",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  backgroundColor: "rgba(255, 255, 255, 0.8)",
+                  backdropFilter: "blur(2px)",
+                  WebkitBackdropFilter: "blur(2px)",
+                  zIndex: 999,
+                  pointerEvents: "auto",
+                }}
+              />
+              <Box
+                align="center"
+                justify="center"
+                width="100%"
+                margin={{ bottom: "medium" }}
+                style={{ position: "relative", zIndex: 1000 }}
+              >
+                <Box
+                  style={{
+                    border: "4px solid #2EC4B6",
+                    borderRadius: "12px",
+                    padding: "8px",
+                    backgroundColor: "rgba(255, 255, 255, 0.95)",
+                    display: "inline-block"
+                  }}
+                >
+                  <Status
+                    participantStatus={45}
+                    partnerStatus={75}
+                  />
+                </Box>
+              </Box>
+            </>
+        )}
+
+        {/* Status component - display if enabled for this phase and not a practice trial */}
         {Flags.isEnabled("enableStatusDisplay") &&
           !props.isPractice &&
           ((props.display === "playerChoice" &&

--- a/src/view/screens/Trial/index.tsx
+++ b/src/view/screens/Trial/index.tsx
@@ -622,7 +622,42 @@ const Trial: FC<Props.Screens.Trial> = (
                   <Status
                     participantStatus={45}
                     partnerStatus={75}
+                    isPractice
                   />
+                </Box>
+
+                <Box
+                  style={{
+                    position: "absolute",
+                    top: "100%",
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    marginTop: "16px",
+                    maxWidth: "400px",
+                    background: "white",
+                    borderRadius: "8px",
+                    padding: "16px",
+                    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
+                    zIndex: 1001
+                  }}
+                >
+                  <Text size="medium" margin={{ bottom: "medium" }}>
+                    {props.spotlight?.message || "Default message"}
+                  </Text>
+
+                  <Box align="center">
+                    <Button
+                      primary
+                      color="button"
+                      label="Continue"
+                      size="medium"
+                      icon={<LinkNext />}
+                      reverse
+                      onClick={() => {
+                        props.handler("Option 1", DEFAULT_POINTS, "Option 1");
+                      }}
+                    />
+                  </Box>
                 </Box>
               </Box>
             </>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,10 +97,17 @@ declare type Trial = {
   answer: Options;                  // Correct answer for the trial ("Option 1" or "Option 2")
   isPractice: boolean;              // Whether this is a practice trial
 
-    // Loading screen configuration (used by Loading screen)
+  // Loading screen configuration (used by Loading screen)
   loadingType?: "matching" | "social" | "default"; // Type of loading: "matching" (partner matching), "social" (status generation), or "default" (generic loading)
   fetchData: boolean;               // Whether to fetch data from server (only used when loadingType is "matching")
   mode: "facilitator" | "mri";
+
+  // Spotlight configuration (used by Trial screen)
+  spotlight?: {
+    enabled: boolean;
+    target: "status" | "options" | "none";
+    message: string;
+  };
 };
 
 // Data type used to enforce trial data storage format

--- a/types/jsPsych.d.ts
+++ b/types/jsPsych.d.ts
@@ -37,6 +37,11 @@ declare type TimelineNode = {
   typeTwo?: string;
   answer?: string;
   isPractice?: boolean;
+  spotlight?: {
+    enabled: boolean;
+    target: "status" | "options" | "none";
+    message: string;
+  };
 
   // Matching screen
   fetchData?: boolean;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -97,6 +97,11 @@ declare namespace Props {
       partnerPoints: number;
       options: Points;
       answer: Options;
+      spotlight?: {
+        enabled: boolean;
+        target: "status" | "options" | "none";
+        message: string;
+      };
       handler: (
         selection: Options,
         points: { options: Points },

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -64,6 +64,7 @@ declare namespace Props {
     type Status = {
       participantStatus: number;
       partnerStatus: number;
+      isPractice?: boolean;
     };
   }
 


### PR DESCRIPTION
* Pop-up highlights the social status bar
* Only displayed on a unique practice trial
* Added `spotlight` prop to enable this potentially for other trials