### PR TITLE
INT-70-Add-manipulation-to-specify-high-or-low-status-during-phases

### DIFF
--- a/src/classes/factories/ScreenPropFactory.ts
+++ b/src/classes/factories/ScreenPropFactory.ts
@@ -17,6 +17,9 @@ import consola from "consola";
 // Utility function
 import { calculatePoints } from "src/util";
 
+// Configuration
+import { Configuration } from "src/configuration";
+
 // Handlers
 import Handler from "src/classes/Handler";
 
@@ -194,7 +197,7 @@ class ScreenPropFactory implements Factory {
         returned.props = {
           trial: this.trial.trial,
           display: this.trial.display,
-          version: "adult",
+          version: Configuration.manipulations.enableAdolescentDASS ? "adolescent" : "adult",
           handler: this.handler.dass.bind(this.handler),
         };
         break;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -127,4 +127,11 @@ export const Configuration = {
     viewWidth: 800,
     viewHeight: 600,
   },
+
+  // Status display configuration
+  statusDisplay: {
+    low: 55,
+    high: 80,
+    variance: 2,
+  }
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -29,6 +29,7 @@ export const Configuration = {
 
     // Questionnaire features
     enableEndingQuestionnaires: false,
+    enableAdolescentDASS: false,
 
     // Status enablement features
     enableStatusPhaseOne: false,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,14 +36,14 @@ export const Configuration = {
     enableStatusPhaseThree: false,
 
     // Status behavior features
-    isHighStatusPhaseOne: false,
-    isHighStatusPhaseTwo: false,
-    isHighStatusPhaseThree: false,
+    isPartnerHighStatusPhaseOne: false,
+    isPartnerHighStatusPhaseTwo: false,
+    isPartnerHighStatusPhaseThree: false,
 
     // Cyberball features
     enableCyberball: false,
     cyberballIsInclusive: true,
-    cyberballPartnerHighStatus: true,
+    cyberballIsPartnerHighStatus: true,
   },
 
   // Feature flags, configure these before building for deployment

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -30,10 +30,15 @@ export const Configuration = {
     // Questionnaire features
     enableEndingQuestionnaires: false,
 
-    // Status features
+    // Status enablement features
     enableStatusPhaseOne: false,
     enableStatusPhaseTwo: false,
     enableStatusPhaseThree: false,
+
+    // Status behavior features
+    isHighStatusPhaseOne: false,
+    isHighStatusPhaseTwo: false,
+    isHighStatusPhaseThree: false,
 
     // Cyberball features
     enableCyberball: false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -397,7 +397,7 @@ if (Configuration.manipulations.enableCyberball === true) {
     type: Configuration.studyName,
     display: "cyberball",
     isInclusive: Configuration.manipulations.cyberballIsInclusive,
-    partnerHighStatus: Configuration.manipulations.cyberballPartnerHighStatus,
+    partnerHighStatus: Configuration.manipulations.cyberballIsPartnerHighStatus,
     probabilities: {
       inclusion: 0.5,
       exclusion: {

--- a/src/view/screens/Trial/index.tsx
+++ b/src/view/screens/Trial/index.tsx
@@ -191,6 +191,26 @@ const Trial: FC<Props.Screens.Trial> = (
     }
   }
 
+  // Calculate status values for participant and partner during actual trials
+  let participantStatus = Configuration.statusDisplay.low;
+  let partnerStatus = Configuration.statusDisplay.high;
+  if (Flags.isEnabled("enableStatusDisplay") && props.isPractice === false) {
+    // If status display is enabled, interpret and apply the manipulations
+    if (props.display === "playerChoice" && Configuration.manipulations.enableStatusPhaseOne) {
+      // Phase One: If `isHighStatusPhaseOne` is true, then the participant is low status and the partner is high status
+      participantStatus = Configuration.manipulations.isPartnerHighStatusPhaseOne ? Configuration.statusDisplay.low : Configuration.statusDisplay.high;
+      partnerStatus = Configuration.manipulations.isPartnerHighStatusPhaseOne ? Configuration.statusDisplay.high : Configuration.statusDisplay.low;
+    } else if (props.display === "playerGuess" && Configuration.manipulations.enableStatusPhaseTwo) {
+      // Phase Two: If `isHighStatusPhaseTwo` is true, then the participant is low status and the partner is high status
+      participantStatus = Configuration.manipulations.isPartnerHighStatusPhaseTwo ? Configuration.statusDisplay.low : Configuration.statusDisplay.high;
+      partnerStatus = Configuration.manipulations.isPartnerHighStatusPhaseTwo ? Configuration.statusDisplay.high : Configuration.statusDisplay.low;
+    } else if (props.display === "playerChoice2" && Configuration.manipulations.enableStatusPhaseThree) {
+      // Phase Three: If `isHighStatusPhaseThree` is true, then the participant is low status and the partner is high status
+      participantStatus = Configuration.manipulations.isPartnerHighStatusPhaseThree ? Configuration.statusDisplay.low : Configuration.statusDisplay.high;
+      partnerStatus = Configuration.manipulations.isPartnerHighStatusPhaseThree ? Configuration.statusDisplay.high : Configuration.statusDisplay.low;
+    }
+  }
+
   /**
    * Handles the selection of an option during a trial
    * @param {("Option 1" | "Option 2")} option - The selected option identifier
@@ -619,8 +639,8 @@ const Trial: FC<Props.Screens.Trial> = (
                   }}
                 >
                   <Status
-                    participantStatus={45}
-                    partnerStatus={75}
+                    participantStatus={participantStatus}
+                    partnerStatus={partnerStatus}
                     isPractice
                   />
                 </Box>
@@ -678,8 +698,8 @@ const Trial: FC<Props.Screens.Trial> = (
               margin={{ bottom: "medium" }}
             >
               <Status
-                participantStatus={75} // Mock value - replace with real data
-                partnerStatus={45} // Mock value - replace with real data
+                participantStatus={participantStatus}
+                partnerStatus={partnerStatus}
               />
             </Box>
           )}

--- a/test/view/screens/Trial.test.tsx
+++ b/test/view/screens/Trial.test.tsx
@@ -38,6 +38,14 @@ jest.mock("src/configuration", () => ({
       enableStatusPhaseOne: false,
       enableStatusPhaseTwo: false,
       enableStatusPhaseThree: false,
+      isPartnerHighStatusPhaseOne: false,
+      isPartnerHighStatusPhaseTwo: false,
+      isPartnerHighStatusPhaseThree: false,
+    },
+    statusDisplay: {
+      low: 55,
+      high: 80,
+      variance: 2,
     },
   },
 }));


### PR DESCRIPTION
* Add new manipulations to specify social status of partners
* Update presentation of status differences (55%, 80%)
* Add manipulation to toggle between adolescent and adult DASS questions